### PR TITLE
Add a default value for the category to fix test issues

### DIFF
--- a/pkg/collectors/policyreport.go
+++ b/pkg/collectors/policyreport.go
@@ -95,18 +95,20 @@ func createPolicyReportListWatchWithClient(client dynamic.Interface, ns string) 
 
 func getReports(clusterID string, pr *v1alpha2.PolicyReport) [][]string {
 	var metrics [][]string
+
 	if clusterID == "" {
 		return metrics
 	}
-	category, policy, result, severity := "", "", "", ""
+
 	for _, reportResult := range pr.Results {
-		var metric []string
-		if reportResult.Category != "" {
-			category = reportResult.Category
-		}
+		var severity string
+
+		result := "fail"
+
 		if reportResult.Result != "" {
 			result = string(reportResult.Result)
 		}
+
 		switch risk := reportResult.Properties["total_risk"]; risk {
 		case "4":
 			severity = "critical"
@@ -119,12 +121,17 @@ func getReports(clusterID string, pr *v1alpha2.PolicyReport) [][]string {
 		default:
 			severity = "unknown"
 		}
-		if reportResult.Policy != "" && category != "" && result != "" {
-			policy = reportResult.Policy
-			metric = append(metric, clusterID, category, policy, result, severity)
-			metrics = append(metrics, metric)
-		}
 
+		if reportResult.Policy != "" {
+			metrics = append(metrics, []string{
+				clusterID,
+				reportResult.Category,
+				reportResult.Policy,
+				result,
+				severity,
+			})
+		}
 	}
+
 	return metrics
 }


### PR DESCRIPTION
The policy report tests have been behaving poorly.  In environments where there is an insights NonCompliance, I think a metric gets created that causes the tests to pass. In some environments that NonCompliance doesn't exist causing this problem -- mainly because the policy resource provided doesn't have a NIST 800-53 category defined so no metric is created by the test. Providing a reasonable default for the category makes sense to me since the standard/category/controls for organizing compliance is optional -- but we don't want to optionally create the metric.

Refs:
 - https://issues.redhat.com/browse/ACM-8851

**Related Issue:**  stolostron/backlog#<ISSUE_NUMBER>

### Description of changes
