### PR TITLE
ACM-38666 - CWE-489 - remove pprof endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"net/http/pprof"
 	"os"
 	"strconv"
 	"strings"
@@ -179,13 +178,6 @@ func serveMetrics(collectors []*metricsstore.MetricsStore, host string, port int
 	klog.Infof("Starting metrics server: %s", listenAddress)
 
 	mux := http.NewServeMux()
-
-	// TODO: This doesn't belong into serveMetrics
-	mux.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
-	mux.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
-	mux.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
-	mux.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
-	mux.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
 
 	// Add metricsPath
 	mux.Handle(metricsPath, &metricHandler{collectors, enableGZIPEncoding})


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-38666

### Description of changes
- Removed pprof endpoint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Removed profiling endpoints from the metrics server.
  * The server no longer exposes `/debug/pprof` routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->